### PR TITLE
fix: bool get returning always true

### DIFF
--- a/src/get.rs
+++ b/src/get.rs
@@ -14,7 +14,7 @@ pub trait Get<T> {
 impl<T: Platform> Get<bool> for Nvs<'_, T> {
     fn get(&mut self, namespace: &Key, key: &Key) -> Result<bool, Error> {
         let value = self.get_primitive(namespace, key, raw::ItemType::U8)?;
-        Ok(value != 0)
+        Ok(value as u8 != 0)
     }
 }
 

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -13,6 +13,22 @@ mod set {
 
         let mut nvs = esp_nvs::Nvs::new(0, flash.len(), &mut flash).unwrap();
 
+        nvs.set(&Key::from_str("hello world"), &Key::from_str("bool"), false)
+            .unwrap();
+        assert_eq!(
+            nvs.get::<bool>(&Key::from_str("hello world"), &Key::from_str("bool"))
+                .unwrap(),
+            false
+        );
+
+        nvs.set(&Key::from_str("hello world"), &Key::from_str("bool"), true)
+            .unwrap();
+        assert_eq!(
+            nvs.get::<bool>(&Key::from_str("hello world"), &Key::from_str("bool"))
+                .unwrap(),
+            true
+        );
+
         nvs.set(&Key::from_str("hello world"), &Key::from_str("u8"), 0xAAu8)
             .unwrap();
         assert_eq!(


### PR DESCRIPTION
I thought it would be useful to have a serde feature for this crate and whilst playing around with that idea I found a bug with `bool`.

I don't fully understand it but the u64 that is returned and compared in the get function needs to be truncated to a u8 first.

I also added some `bool` tests to catch ensure the behaviour is correct.

