### PR TITLE
fix: write_aligned fails when buf.len() < T::WRITE_SIZE

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -385,7 +385,9 @@ pub(crate) fn write_aligned<T: Platform>(
         let pivot = T::align_write_floor(bytes.len());
         let header = &bytes[..pivot];
         let trailer = &bytes[pivot..];
-        hal.write(offset, header)?;
+        if !header.is_empty() {
+            hal.write(offset, header)?;
+        }
 
         // no need to write the trailer if remaining data is all ones - this the default state of the flash
         if bytes[pivot..].iter().any(|&e| e != 0xFF) {

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -120,6 +120,14 @@ mod set {
         let mut flash = common::Flash::new(2);
         let mut nvs = esp_nvs::Nvs::new(0, flash.len(), &mut flash).unwrap();
 
+        nvs.set(&Key::from_str("hello world"), &Key::from_str("char"), "X")
+            .unwrap();
+        assert_eq!(
+            nvs.get::<String>(&Key::from_str("hello world"), &Key::from_str("char"))
+                .unwrap(),
+            "X"
+        );
+
         nvs.set(
             &Key::from_str("hello world"),
             &Key::from_str("short str"),


### PR DESCRIPTION
During testing I found that small strs < 4 bytes long would cause a failed assertion in the `common::Flash::write` method: `bytes.len() > 0);`  
This was due to `pivot` in the `write_aligned` method == 0 and calling `hal.write` with an empty header slice.

I fixed it by checking if the header is empty but I'm not sure if any other changes need to be made.

 