### PR TITLE
feat: list keys and namespaces

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -579,6 +579,20 @@ impl ThinPage {
 
         Ok(())
     }
+
+    /// Returns an iterator over all items in this page.
+    ///
+    /// # Errors
+    ///
+    /// This functions iterator may return a `FlashError` if there is
+    /// an error reading from flash.
+    pub(crate) fn items<'a, T: Platform>(&'a self, hal: &'a mut T) -> IterPageItems<'a, T> {
+        IterPageItems {
+            page: self,
+            hal,
+            iter: self.item_hash_list.iter(),
+        }
+    }
 }
 
 impl PartialEq<Self> for ThinPage {
@@ -627,6 +641,33 @@ impl Debug for ThinPage {
         let used_entry_count = self.used_entry_count;
         let entry_hash_list_len = self.item_hash_list.len();
         f.write_fmt(format_args!("erased_entry_count: {erased_entry_count}, used_entry_count: {used_entry_count}, entry_hash_list_len: {entry_hash_list_len}}}"))
+    }
+}
+
+pub(crate) struct IterPageItems<'a, T: Platform> {
+    page: &'a ThinPage,
+    hal: &'a mut T,
+    iter: core::slice::Iter<'a, ItemHashListEntry>,
+}
+
+impl<'a, T: Platform> IterPageItems<'a, T> {
+    pub(crate) fn switch_to_page(&mut self, new_page: &'a ThinPage) {
+        self.page = new_page;
+        self.iter = self.page.item_hash_list.iter();
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.iter.as_slice().is_empty()
+    }
+}
+
+impl<'a, T: Platform> Iterator for IterPageItems<'a, T> {
+    type Item = Result<Item, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let entry = self.iter.next()?;
+
+        Some(self.page.load_item(self.hal, entry.index))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,9 +104,9 @@ pub use set::Set;
 extern crate alloc;
 
 use crate::error::Error;
-use crate::internal::{ChunkIndex, ThinPage};
+use crate::internal::{ChunkIndex, IterPageItems, ThinPage, VersionOffset};
 use crate::platform::Platform;
-use crate::raw::{ENTRIES_PER_PAGE, FLASH_SECTOR_SIZE};
+use crate::raw::{ENTRIES_PER_PAGE, FLASH_SECTOR_SIZE, Item, ItemType};
 use alloc::collections::{BTreeMap, BinaryHeap};
 use alloc::vec::Vec;
 use core::fmt;
@@ -234,6 +234,20 @@ impl<T: Platform> Nvs<T> {
         }
     }
 
+    /// Returns an iterator over all known namespaces.
+    pub fn namespaces(&self) -> impl Iterator<Item = &Key> {
+        self.namespaces.keys()
+    }
+
+    /// Returns an iterator over all keys in all namespaces.
+    ///
+    /// # Errors
+    ///
+    /// The iterator yields an error if there is a flash read error.
+    pub fn keys(&mut self) -> impl Iterator<Item = Result<(Key, Key), Error>> {
+        IterKeys::new(&self.pages, &mut self.hal, &self.namespaces)
+    }
+
     /// Delete a key
     ///
     /// Ignores missing keys or the namespaces
@@ -335,5 +349,94 @@ impl<T: Platform> Nvs<T> {
             entries_per_page,
             entries_overall,
         })
+    }
+}
+
+struct IterLoadedItems<'a, T: Platform> {
+    pages: &'a [ThinPage],
+    current: Option<IterPageItems<'a, T>>,
+}
+
+impl<'a, T: Platform> IterLoadedItems<'a, T> {
+    fn new(mut pages: &'a [ThinPage], hal: &'a mut T) -> Self {
+        let first = pages.split_off_first();
+
+        Self {
+            pages,
+            current: first.map(|page| page.items(hal)),
+        }
+    }
+}
+
+impl<'a, T: Platform> Iterator for IterLoadedItems<'a, T> {
+    type Item = Result<Item, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // self.current is only None if there are no pages at all
+        let current = self.current.as_mut()?;
+
+        // if the current page is exhausted, move to next page that has items (or until we run out of pages)
+        while current.is_empty() {
+            let next_page = self.pages.split_off_first()?;
+
+            current.switch_to_page(next_page);
+        }
+
+        current.next()
+    }
+}
+
+struct IterKeys<'a, T: Platform> {
+    items: IterLoadedItems<'a, T>,
+    namespaces: &'a BTreeMap<Key, u8>,
+}
+
+impl<'a, T: Platform> IterKeys<'a, T> {
+    fn new(pages: &'a [ThinPage], hal: &'a mut T, namespaces: &'a BTreeMap<Key, u8>) -> Self {
+        Self {
+            items: IterLoadedItems::new(pages, hal),
+            namespaces,
+        }
+    }
+
+    fn item_to_keys(&self, item: Item) -> (Key, Key) {
+        let (namespace_key, _) = self
+            .namespaces
+            .iter()
+            .find(|(_, idx)| **idx == item.namespace_index)
+            // a key should always have a namespace
+            .unwrap();
+
+        (*namespace_key, item.key)
+    }
+}
+
+impl<'a, T: Platform> Iterator for IterKeys<'a, T> {
+    type Item = Result<(Key, Key), Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            return match self.items.next()? {
+                Ok(item) => {
+                    // Skip namespace entries (namespace_index == 0), and blobs (they are represented by their BlobData)
+                    if item.namespace_index == 0
+                        || item.type_ == ItemType::Blob
+                        || item.type_ == ItemType::BlobIndex
+                    {
+                        continue;
+                    }
+
+                    if item.type_ == ItemType::BlobData
+                        && item.chunk_index != VersionOffset::V0 as u8
+                        && item.chunk_index != VersionOffset::V1 as u8
+                    {
+                        continue;
+                    }
+
+                    Some(Ok(self.item_to_keys(item)))
+                }
+                Err(err) => Some(Err(err)),
+            };
+        }
     }
 }

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -134,6 +134,82 @@ fn from_generated_partition() {
 }
 
 #[test]
+fn iter_namespaces() {
+    let mut flash = common::Flash::new_from_file("tests/assets/test_nvs_data.bin");
+
+    let nvs = esp_nvs::Nvs::new(0, flash.len(), &mut flash).unwrap();
+
+    assert_eq!(
+        nvs.namespaces().collect::<Vec<_>>(),
+        vec![
+            &Key::from_array(b"namespace_one"),
+            &Key::from_array(b"namespace_two")
+        ]
+    );
+}
+
+#[test]
+fn iter_keys() {
+    let mut flash = common::Flash::new_from_file("tests/assets/test_nvs_data.bin");
+
+    let mut nvs = esp_nvs::Nvs::new(0, flash.len(), &mut flash).unwrap();
+
+    assert_eq!(
+        nvs.keys().collect::<Vec<_>>(),
+        vec![
+            Ok((
+                Key::from_array(b"namespace_one"),
+                Key::from_array(b"example_u8")
+            )),
+            Ok((
+                Key::from_array(b"namespace_one"),
+                Key::from_array(b"example_i8")
+            )),
+            Ok((
+                Key::from_array(b"namespace_one"),
+                Key::from_array(b"example_u16")
+            )),
+            Ok((
+                Key::from_array(b"namespace_one"),
+                Key::from_array(b"example_i16")
+            )),
+            Ok((
+                Key::from_array(b"namespace_one"),
+                Key::from_array(b"example_u32")
+            )),
+            Ok((
+                Key::from_array(b"namespace_one"),
+                Key::from_array(b"example_i32")
+            )),
+            Ok((
+                Key::from_array(b"namespace_one"),
+                Key::from_array(b"example_s_short")
+            )),
+            Ok((
+                Key::from_array(b"namespace_one"),
+                Key::from_array(b"example_s_long")
+            )),
+            Ok((
+                Key::from_array(b"namespace_one"),
+                Key::from_array(b"example_b_short")
+            )),
+            Ok((
+                Key::from_array(b"namespace_one"),
+                Key::from_array(b"example_b_long")
+            )),
+            Ok((
+                Key::from_array(b"namespace_two"),
+                Key::from_array(b"example_u8")
+            )),
+            Ok((
+                Key::from_array(b"namespace_two"),
+                Key::from_array(b"only_in_two")
+            ))
+        ]
+    );
+}
+
+#[test]
 fn corrupt_page() {
     let mut flash = common::Flash::new_from_file("tests/assets/test_nvs_data.bin");
 


### PR DESCRIPTION
This PR implements parts of #6. An erase method is missing, but users can implement this by iterating through the keys and then removing them.